### PR TITLE
getatoms: Consider Vulnerabilities component like Stabilization for --no-depends

### DIFF
--- a/getatoms.py
+++ b/getatoms.py
@@ -165,7 +165,7 @@ def main():
 				if current_bug['status'] == 'RESOLVED':
 					continue
 
-				if current_bug['component'] == 'Stabilization' or current_bug['component'] == 'Keywording':
+				if current_bug['component'] in ['Stabilization', 'Keywording', 'Vulnerabilities']:
 
 					sanity_checked = False
 					for flag in current_bug['flags']:


### PR DESCRIPTION
Before if a security bug depends on another security bug and both are conducting
the stabilization on their own bug, it would never let the higher level bug be
shown with --no-depends unti ALL arches are done in the dependent bug, which is
a rather suboptimal treatment to a security stabilization.