### PR TITLE
getatoms: Don't throw exception when there is a stabilization attachment but no package list

### DIFF
--- a/getatoms.py
+++ b/getatoms.py
@@ -147,7 +147,7 @@ def main():
 
 			for flag in attachment['flags']:
 				if flag['name'] == 'stabilization-list' and flag['status'] == '+':
-					if atoms[-1] is not "\n":
+					if atoms and atoms[-1] is not "\n":
 						atoms += "\n"
 					atoms += str(attachment['data'])
 


### PR DESCRIPTION
If there was no package list, then atoms is still an empty string and [-1] will fail with string index error. The PR fixes this.