### PR TITLE
getatoms: remove global portage import

### DIFF
--- a/getatoms.py
+++ b/getatoms.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 import argparse
 import base64
 import logging
-import portage
 import requests
 import os
 import sys


### PR DESCRIPTION
We only need it to pull ARCH when it's not provided, so don't import it
globally.